### PR TITLE
Fix typo in git submodule definition

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,4 +21,4 @@
 	url = https://github.com/iimarckus/stadiumgs-0x3fed000
 [submodule "stadiumgs/gameboy"]
 	path = stadiumgs/gameboy
-	url = https://github.com/iimarckus/stadiumgs-gameboy/
+	url = https://github.com/iimarckus/stadiumgs-gameboy


### PR DESCRIPTION
Git doesn't like the trailing slash in the .gitmodules urls. It makes git submodule updates fail. This fixes it