### PR TITLE
Add windows instructions to README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,9 +366,12 @@ submodules:
 	git submodule update --init --recursive
 
 split:
-	rm -rf $(DATA_DIRS) $(ASM_DIRS) && ./tools/n64splat/split.py $(SPLAT_YAML)
+	rm -rf $(DATA_DIRS) $(ASM_DIRS)
 
-setup: distclean submodules split
+splat:
+	$(SPLAT)
+
+setup: distclean submodules split splat
 	
 $(BUILD_DIR):
 	echo $(C_FILES)
@@ -411,7 +414,7 @@ $(BUILD_DIR)/$(ROM): $(BUILD_DIR)/$(TARGET).bin
 verify: $(BUILD_DIR)/$(ROM)
 	md5sum -c checksum.md5
 
-.PHONY: all clean distclean default split setup
+.PHONY: all clean distclean default split splat setup
 
 print-% : ; $(info $* is a $(flavor $*) variable set to [$($*)]) @true
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,20 @@ It builds the following ROMs:
 
 Note: To use this repository, you must already have a rom for the game.
 
-# Prerequisites
+## Installation
+
+### Windows
+
+Install WSL and a distro of your choice following
+[Windows Subsystem for Linux Installation Guide for Windows 10.](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
+We recommend either Debian or Ubuntu 20.04 Linux distributions under WSL.
+
+Next, clone the Pokemon Stadium repo from within the Linux shell, this step is important:
+`git clone https://github.com/pret/pokestadium.git`
+
+Then continue following the directions in the [Linux](#linux) installation section below.
+
+### Linux
 
 Under Debian / Ubuntu (which we recommend using), you can install them with the following commands:
 


### PR DESCRIPTION
* Instructions to install WSL
* Add `make splat` command

When I run `make setup` I run into following error. Running `make splat` works. I'm not a python expert so I don't know what's going on here.

```
asm/data/fragments/77/ && ./tools/n64splat/split.py splat.yaml
Traceback (most recent call last):
  File "tools/n64splat/split.py", line 8, in <module>
    import rabbitizer
ModuleNotFoundError: No module named 'rabbitizer'
make: *** [Makefile:372: splat] Error 1
```