### PR TITLE
Fix ultralib build on macOS

### DIFF
--- a/lib/ultralib/Makefile
+++ b/lib/ultralib/Makefile
@@ -26,7 +26,7 @@ ifeq ($(VERBOSE),0)
 endif
 
 CPP := cpp -P
-AR := ar
+AR := $(CROSS)ar
 
 VERSION_D := 1
 VERSION_E := 2


### PR DESCRIPTION
Use homebrew / GNU toolchains for `ar` instead of builtin MacOS command.

Tested on M4 Mac Studio