### PR TITLE
Error: symbol ".text" defined twice

### DIFF
--- a/tools/asm-processor/asm_processor.py
+++ b/tools/asm-processor/asm_processor.py
@@ -1335,7 +1335,9 @@ def fixup_objfile(objfile_name, functions, asm_prelude, assembler, output_enc, d
                 if not existing:
                     name_to_sym[s.name] = s
                     newer_syms.append(s)
-                elif s.st_shndx != SHN_UNDEF:
+                elif s.st_shndx != SHN_UNDEF and not (
+                    existing.st_shndx == s.st_shndx and existing.st_value == s.st_value
+                ):
                     raise Failure("symbol \"" + s.name + "\" defined twice")
                 else:
                     s.replace_by = existing


### PR DESCRIPTION
Build error when using mips-elf

Issue: https://github.com/simonlindholm/asm-processor/issues/25

Fixed: https://github.com/simonlindholm/asm-processor/commit/6b9b0601021ab9ffb44a25636771edd49451a592